### PR TITLE
Add context for client operations

### DIFF
--- a/k8snodedecorator/labels.go
+++ b/k8snodedecorator/labels.go
@@ -35,6 +35,9 @@ func UpdateNodeLabels(
 		return fmt.Errorf("instance data received from Linode metadata service is nil")
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, timeout) // FIXME: set timeout to some value
+	defer cancel()
+
 	node, err := GetCurrentNode(ctx, clientset)
 	if err != nil {
 		return fmt.Errorf("failed to get the node: %w", err)

--- a/k8snodedecorator/labels.go
+++ b/k8snodedecorator/labels.go
@@ -27,6 +27,7 @@ func SetLabel(node *corev1.Node, key, newValue string) (changed bool) {
 }
 
 func UpdateNodeLabels(
+	ctx context.Context,
 	clientset *kubernetes.Clientset,
 	instanceData *metadata.InstanceData,
 ) error {
@@ -34,7 +35,7 @@ func UpdateNodeLabels(
 		return fmt.Errorf("instance data received from Linode metadata service is nil")
 	}
 
-	node, err := GetCurrentNode(clientset)
+	node, err := GetCurrentNode(ctx, clientset)
 	if err != nil {
 		return fmt.Errorf("failed to get the node: %w", err)
 	}
@@ -78,7 +79,7 @@ func UpdateNodeLabels(
 		return nil
 	}
 
-	_, err = clientset.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+	_, err = clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
 	if err != nil {
 		klog.Errorf("Failed to update labels: %s", err.Error())
 		return err

--- a/k8snodedecorator/node.go
+++ b/k8snodedecorator/node.go
@@ -14,6 +14,6 @@ func SetNodeName(newNodeName string) {
 	nodeName = newNodeName
 }
 
-func GetCurrentNode(clientset *kubernetes.Clientset) (*corev1.Node, error) {
-	return clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+func GetCurrentNode(ctx context.Context, clientset *kubernetes.Clientset) (*corev1.Node, error) {
+	return clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 }

--- a/main.go
+++ b/main.go
@@ -100,10 +100,12 @@ func main() {
 
 	klog.Infof("Starting Linode Kubernetes Node Decorator: version %s", version)
 	klog.Infof("The poll interval is set to %v.", interval)
-	klog.Infof("The timeout is set to %v.", timeout)
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+	ctx, stop := signal.NotifyContext(context.Background(),
+		os.Interrupt,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+	defer stop()
 
 	clientset, err := GetClientset()
 	if err != nil {


### PR DESCRIPTION
Adding a proper context as per https://github.com/linode/k8s-node-decorator/issues/11.
Default is `30s`,  open to change on that...
